### PR TITLE
Add temp fix for Google Play Services 15.0.90 crash

### DIFF
--- a/src/autoapp/Service/AndroidAutoEntity.cpp
+++ b/src/autoapp/Service/AndroidAutoEntity.cpp
@@ -247,6 +247,15 @@ void AndroidAutoEntity::triggerQuit()
     }
 }
 
+/*
+ * As of Google Play Services 15.0.90 (Jan 29 2019), this function causes
+ * the Android Auto interface to crash without the ability to cover seconds
+ * after connection. 
+ * 
+ * Simply commenting this function out is a temporary fix to allow Crankshaft
+ * users to use Android Auto with the most Google Play Services >= 15.0.90
+ * but should be properly addressed in the future.
+ *
 void AndroidAutoEntity::schedulePing()
 {
     auto promise = IPinger::Promise::defer(strand_);
@@ -265,6 +274,8 @@ void AndroidAutoEntity::schedulePing()
 
     pinger_->ping(std::move(promise));
 }
+
+*/
 
 void AndroidAutoEntity::sendPing()
 {


### PR DESCRIPTION
As noted in opencardev/crankshaft#304, with Google Play Services >= 15.0.90 the AndroidAutoEntity::schedulePing() function here:

https://github.com/opencardev/openauto/blob/355c1d3e21e96c61e5bb7fc3d6106329db405162/src/autoapp/Service/AndroidAutoEntity.cpp#L250-L267

The Android Auto UI crashes a few seconds after connection. By commenting out this function, it cannot run and provides a temporary fix lettings users get to and stay in Android Auto's UI without downgrading Google Play Services.