### PR TITLE
[blocked by PR opencardev/aasdk#2] Fix compatibility with latest Android Auto

### DIFF
--- a/include/f1x/openauto/autoapp/Service/VideoService.hpp
+++ b/include/f1x/openauto/autoapp/Service/VideoService.hpp
@@ -48,6 +48,7 @@ public:
     void onChannelOpenRequest(const aasdk::proto::messages::ChannelOpenRequest& request) override;
     void onAVChannelSetupRequest(const aasdk::proto::messages::AVChannelSetupRequest& request) override;
     void onAVChannelStartIndication(const aasdk::proto::messages::AVChannelStartIndication& indication) override;
+    void onAVChannelStopIndication(const aasdk::proto::messages::AVChannelStopIndication& indication) override;
     void onAVMediaWithTimestampIndication(aasdk::messenger::Timestamp::ValueType timestamp, const aasdk::common::DataConstBuffer& buffer) override;
     void onAVMediaIndication(const aasdk::common::DataConstBuffer& buffer) override;
     void onVideoFocusRequest(const aasdk::proto::messages::VideoFocusRequest& request) override;

--- a/src/autoapp/Service/AndroidAutoEntity.cpp
+++ b/src/autoapp/Service/AndroidAutoEntity.cpp
@@ -302,6 +302,8 @@ void AndroidAutoEntity::sendPing()
     promise->then([]() {}, std::bind(&AndroidAutoEntity::onChannelError, this->shared_from_this(), std::placeholders::_1));
 
     aasdk::proto::messages::PingRequest request;
+    auto timestamp = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now().time_since_epoch());
+    request.set_timestamp(timestamp.count());
     controlServiceChannel_->sendPingRequest(request, std::move(promise));
 }
 

--- a/src/autoapp/Service/VideoService.cpp
+++ b/src/autoapp/Service/VideoService.cpp
@@ -110,6 +110,13 @@ void VideoService::onAVChannelStartIndication(const aasdk::proto::messages::AVCh
     channel_->receive(this->shared_from_this());
 }
 
+void VideoService::onAVChannelStopIndication(const aasdk::proto::messages::AVChannelStopIndication& indication)
+{
+    OPENAUTO_LOG(info) << "[VideoService] stop indication";
+
+    channel_->receive(this->shared_from_this());
+}
+
 void VideoService::onAVMediaWithTimestampIndication(aasdk::messenger::Timestamp::ValueType timestamp, const aasdk::common::DataConstBuffer& buffer)
 {
     videoOutput_->write(timestamp, buffer);


### PR DESCRIPTION
Some fixes to work with updated aasdk (see https://github.com/opencardev/aasdk/pull/2).

fixes opencardev/crankshaft#352.