### PR TITLE
Add support for sending NAVIGATION button code to AA

### DIFF
--- a/include/f1x/openauto/autoapp/Configuration/Configuration.hpp
+++ b/include/f1x/openauto/autoapp/Configuration/Configuration.hpp
@@ -213,6 +213,7 @@ private:
     static const std::string cInputScrollWheelButtonKey;
     static const std::string cInputBackButtonKey;
     static const std::string cInputEnterButtonKey;
+    static const std::string cInputNavButtonKey;
 };
 
 }

--- a/src/autoapp/Configuration/Configuration.cpp
+++ b/src/autoapp/Configuration/Configuration.cpp
@@ -85,6 +85,7 @@ const std::string Configuration::cInputDownButtonKey = "Input.DownButton";
 const std::string Configuration::cInputScrollWheelButtonKey = "Input.ScrollWheelButton";
 const std::string Configuration::cInputBackButtonKey = "Input.BackButton";
 const std::string Configuration::cInputEnterButtonKey = "Input.EnterButton";
+const std::string Configuration::cInputNavButtonKey = "Input.NavButton";
 
 Configuration::Configuration()
 {
@@ -698,6 +699,7 @@ void Configuration::readButtonCodes(boost::property_tree::ptree& iniConfig)
     this->insertButtonCode(iniConfig, cInputScrollWheelButtonKey, aasdk::proto::enums::ButtonCode::SCROLL_WHEEL);
     this->insertButtonCode(iniConfig, cInputBackButtonKey, aasdk::proto::enums::ButtonCode::BACK);
     this->insertButtonCode(iniConfig, cInputEnterButtonKey, aasdk::proto::enums::ButtonCode::ENTER);
+    this->insertButtonCode(iniConfig, cInputNavButtonKey, aasdk::proto::enums::ButtonCode::NAVIGATION);
 }
 
 void Configuration::insertButtonCode(boost::property_tree::ptree& iniConfig, const std::string& buttonCodeKey, aasdk::proto::enums::ButtonCode::Enum buttonCode)
@@ -726,6 +728,7 @@ void Configuration::writeButtonCodes(boost::property_tree::ptree& iniConfig)
     iniConfig.put<bool>(cInputScrollWheelButtonKey, std::find(buttonCodes_.begin(), buttonCodes_.end(), aasdk::proto::enums::ButtonCode::SCROLL_WHEEL) != buttonCodes_.end());
     iniConfig.put<bool>(cInputBackButtonKey, std::find(buttonCodes_.begin(), buttonCodes_.end(), aasdk::proto::enums::ButtonCode::BACK) != buttonCodes_.end());
     iniConfig.put<bool>(cInputEnterButtonKey, std::find(buttonCodes_.begin(), buttonCodes_.end(), aasdk::proto::enums::ButtonCode::ENTER) != buttonCodes_.end());
+    iniConfig.put<bool>(cInputNavButtonKey, std::find(buttonCodes_.begin(), buttonCodes_.end(), aasdk::proto::enums::ButtonCode::NAVIGATION) != buttonCodes_.end());
 }
 
 }

--- a/src/autoapp/Projection/InputDevice.cpp
+++ b/src/autoapp/Projection/InputDevice.cpp
@@ -164,6 +164,10 @@ bool InputDevice::handleKeyEvent(QEvent* event, QKeyEvent* key)
         buttonCode = aasdk::proto::enums::ButtonCode::SCROLL_WHEEL;
         break;
 
+    case Qt::Key_F:
+        buttonCode = aasdk::proto::enums::ButtonCode::NAVIGATION;
+        break;
+
     default:
         return true;
     }

--- a/src/autoapp/UI/SettingsWindow.cpp
+++ b/src/autoapp/UI/SettingsWindow.cpp
@@ -565,6 +565,7 @@ void SettingsWindow::loadButtonCheckBoxes()
     ui_->checkBoxScrollWheelButton->setChecked(std::find(buttonCodes.begin(), buttonCodes.end(), aasdk::proto::enums::ButtonCode::SCROLL_WHEEL) != buttonCodes.end());
     ui_->checkBoxBackButton->setChecked(std::find(buttonCodes.begin(), buttonCodes.end(), aasdk::proto::enums::ButtonCode::BACK) != buttonCodes.end());
     ui_->checkBoxEnterButton->setChecked(std::find(buttonCodes.begin(), buttonCodes.end(), aasdk::proto::enums::ButtonCode::ENTER) != buttonCodes.end());
+    ui_->checkBoxNavButton->setChecked(std::find(buttonCodes.begin(), buttonCodes.end(), aasdk::proto::enums::ButtonCode::NAVIGATION) != buttonCodes.end());
 }
 
 void SettingsWindow::setButtonCheckBoxes(bool value)
@@ -585,6 +586,7 @@ void SettingsWindow::setButtonCheckBoxes(bool value)
     ui_->checkBoxScrollWheelButton->setChecked(value);
     ui_->checkBoxBackButton->setChecked(value);
     ui_->checkBoxEnterButton->setChecked(value);
+    ui_->checkBoxNavButton->setChecked(value);
 }
 
 void SettingsWindow::saveButtonCheckBoxes()
@@ -606,6 +608,7 @@ void SettingsWindow::saveButtonCheckBoxes()
     this->saveButtonCheckBox(ui_->checkBoxScrollWheelButton, buttonCodes, aasdk::proto::enums::ButtonCode::SCROLL_WHEEL);
     this->saveButtonCheckBox(ui_->checkBoxBackButton, buttonCodes, aasdk::proto::enums::ButtonCode::BACK);
     this->saveButtonCheckBox(ui_->checkBoxEnterButton, buttonCodes, aasdk::proto::enums::ButtonCode::ENTER);
+    this->saveButtonCheckBox(ui_->checkBoxNavButton, buttonCodes, aasdk::proto::enums::ButtonCode::NAVIGATION);
     configuration_->setButtonCodes(buttonCodes);
 }
 

--- a/src/autoapp/UI/settingswindow.ui
+++ b/src/autoapp/UI/settingswindow.ui
@@ -2464,6 +2464,13 @@ QSlider::groove:horizontal { background: #6d6d6d; height: 32px;}</string>
            </property>
           </widget>
          </item>
+         <item row="1" column="4">
+          <widget class="QCheckBox" name="checkBoxNavButton">
+           <property name="text">
+            <string>Nav [F]</string>
+           </property>
+          </widget>
+         </item>
          <item row="2" column="3">
           <widget class="QCheckBox" name="checkBoxScrollWheelButton">
            <property name="text">


### PR DESCRIPTION
It is mapped to the "F" key like Android Auto Pro.
This requires the aasdk change here: https://github.com/opencardev/aasdk/pull/4
