### PR TITLE
Rework QtAudioOutput to fix buffer underruns

### DIFF
--- a/include/f1x/openauto/autoapp/Projection/QtAudioOutput.hpp
+++ b/include/f1x/openauto/autoapp/Projection/QtAudioOutput.hpp
@@ -60,7 +60,7 @@ protected slots:
 
 private:
     QAudioFormat audioFormat_;
-    SequentialBuffer audioBuffer_;
+    QIODevice * audioBuffer_;
     std::unique_ptr<QAudioOutput> audioOutput_;
     bool playbackStarted_;
 };


### PR DESCRIPTION
This greatly improves the buffer underruns that cause audio crackling with Qt audio.