### PR TITLE
Keyboard support in openauto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 # Add any directories, files, or patterns you don't want to be tracked by version control
 lib/
 bin/
+build/
+.vscode/
+openauto.ini
 CMakeLists.txt.user

--- a/include/f1x/openauto/autoapp/UI/ConnectDialog.hpp
+++ b/include/f1x/openauto/autoapp/UI/ConnectDialog.hpp
@@ -2,6 +2,7 @@
 
 #include <QDialog>
 #include <QStringListModel>
+#include <QKeyEvent>
 #include <f1x/aasdk/TCP/ITCPEndpoint.hpp>
 #include <f1x/aasdk/TCP/ITCPWrapper.hpp>
 #include <f1x/openauto/autoapp/Configuration/IRecentAddressesList.hpp>
@@ -40,6 +41,9 @@ private slots:
     void onConnectionSucceed(aasdk::tcp::ITCPEndpoint::SocketPointer socket, const std::string& ipAddress);
     void onRecentAddressClicked(const QModelIndex& index);
     void onUpdateButtonClicked();
+
+protected:
+    void keyPressEvent(QKeyEvent *event);
 
 private:
     void insertIpAddress(const std::string& ipAddress);

--- a/include/f1x/openauto/autoapp/UI/MainWindow.hpp
+++ b/include/f1x/openauto/autoapp/UI/MainWindow.hpp
@@ -69,7 +69,7 @@ public:
     ~MainWindow() override;
     QMediaPlayer* player;
     QFileSystemWatcher* watcher;
-    QFileSystemWatcher* watcher_tmp;
+    QFileSystemWatcher* watcher_tmp; 
 
 signals:
     void exit();
@@ -159,8 +159,6 @@ private slots:
     void resetRetryUSBMessage();
     void updateNetworkInfo();
     bool check_file_exist(const char *filename);
-    void KeyPress(QString key);
-
     void hostModeStateChanged(QBluetoothLocalDevice::HostMode);
 
     //void on_AlbumCoverListView_clicked(const QModelIndex &index);
@@ -276,33 +274,8 @@ private:
     QBluetoothLocalDevice *localDevice;
 
 protected:
-    void keyPressEvent(QKeyEvent *event) override
-    {
-        if (event->key() == Qt::Key_C) {
-            MainWindow::KeyPress("C");
-        }
-        if (event->key() == Qt::Key_X) {
-            MainWindow::KeyPress("X");
-        }
-        if (event->key() == Qt::Key_V) {
-            MainWindow::KeyPress("V");
-        }
-        if (event->key() == Qt::Key_N) {
-            MainWindow::KeyPress("N");
-        }
-        if (event->key() == Qt::Key_B) {
-            MainWindow::KeyPress("B");
-        }
-        if (event->key() == Qt::Key_H) {
-            MainWindow::KeyPress("H");
-        }
-        if (event->key() == Qt::Key_A) {
-            MainWindow::KeyPress("A");
-        }
-        if (event->key() == Qt::Key_L) {
-            MainWindow::KeyPress("L");
-        }
-    }
+    void keyPressEvent(QKeyEvent *event);
+
 };
 
 }

--- a/include/f1x/openauto/autoapp/UI/SettingsWindow.hpp
+++ b/include/f1x/openauto/autoapp/UI/SettingsWindow.hpp
@@ -22,6 +22,7 @@
 #include <QWidget>
 #include <f1x/openauto/autoapp/Configuration/IConfiguration.hpp>
 #include <QFileDialog>
+#include <QKeyEvent>
 #include <sys/sysinfo.h>
 
 class QCheckBox;
@@ -48,6 +49,9 @@ public:
     explicit SettingsWindow(configuration::IConfiguration::Pointer configuration, QWidget *parent = nullptr);
     ~SettingsWindow() override;
     void loadSystemValues();
+
+protected:
+    void keyPressEvent(QKeyEvent *event);
 
 private slots:
     void unpairAll();

--- a/include/f1x/openauto/autoapp/UI/UpdateDialog.hpp
+++ b/include/f1x/openauto/autoapp/UI/UpdateDialog.hpp
@@ -6,6 +6,7 @@
 #include <QStringList>
 #include <QTimer>
 #include <QFileInfo>
+#include <QKeyEvent>
 
 namespace Ui {
 class UpdateDialog;
@@ -39,6 +40,9 @@ private slots:
     void on_pushButtonUpdateSystem_clicked();
     void on_pushButtonUpdateCheck_clicked();
     void on_pushButtonUpdateCancel_clicked();
+
+protected:
+    void keyPressEvent(QKeyEvent *event);
 
 private:
     Ui::UpdateDialog *ui_;

--- a/src/autoapp/UI/ConnectDialog.cpp
+++ b/src/autoapp/UI/ConnectDialog.cpp
@@ -202,6 +202,14 @@ void ConnectDialog::insertIpAddress(const std::string& ipAddress)
     this->loadRecentList();
 }
 
+void f1x::openauto::autoapp::ui::ConnectDialog::keyPressEvent(QKeyEvent *event)
+{
+    if(event->key() == Qt::Key_Escape)
+    {
+        ConnectDialog::close();
+    }
+}
+
 }
 }
 }

--- a/src/autoapp/UI/MainWindow.cpp
+++ b/src/autoapp/UI/MainWindow.cpp
@@ -86,6 +86,7 @@ MainWindow::MainWindow(configuration::IConfiguration::Pointer configuration, QWi
     this->wallpaperEQFileExists = check_file_exist("wallpaper-eq.png");
 
     ui_->setupUi(this);
+
     connect(ui_->pushButtonSettings, &QPushButton::clicked, this, &MainWindow::openSettings);
     connect(ui_->pushButtonSettings2, &QPushButton::clicked, this, &MainWindow::openSettings);
     connect(ui_->pushButtonUpdate, &QPushButton::clicked, this, &MainWindow::openUpdateDialog);
@@ -779,31 +780,31 @@ void f1x::openauto::autoapp::ui::MainWindow::updateAlpha()
         this->alpha_current_str = value;
         double alpha = value/100.0;
         QString alp=QString::number(alpha);
-        ui_->pushButtonExit->setStyleSheet( "background-color: rgba(164, 0, 0, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonShutdown->setStyleSheet( "background-color: rgba(239, 41, 41, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonReboot->setStyleSheet( "background-color: rgba(252, 175, 62, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonCancel->setStyleSheet( "background-color: rgba(32, 74, 135, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonBrightness->setStyleSheet( "background-color: rgba(245, 121, 0, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonVolume->setStyleSheet( "background-color: rgba(64, 191, 191, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonLock->setStyleSheet( "background-color: rgba(15, 54, 5, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonSettings->setStyleSheet( "background-color: rgba(138, 226, 52, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonDay->setStyleSheet( "background: rgba(252, 233, 79, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonNight->setStyleSheet( "background-color: rgba(114, 159, 207, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonCameraShow->setStyleSheet( "background-color: rgba(100, 62, 4, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonWifi->setStyleSheet( "background-color: rgba(252, 175, 62, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonToggleGUI->setStyleSheet( "background-color: rgba(237, 164, 255, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButton_c1->setStyleSheet( "background-color: rgba(" + this->custom_button_color_c1 + ", " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);");
-        ui_->pushButton_c2->setStyleSheet( "background-color: rgba(" + this->custom_button_color_c2 + ", " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);");
-        ui_->pushButton_c3->setStyleSheet( "background-color: rgba(" + this->custom_button_color_c3 + ", " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);");
-        ui_->pushButton_c4->setStyleSheet( "background-color: rgba(" + this->custom_button_color_c4 + ", " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);");
-        ui_->pushButton_c5->setStyleSheet( "background-color: rgba(" + this->custom_button_color_c5 + ", " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);");
-        ui_->pushButton_c6->setStyleSheet( "background-color: rgba(" + this->custom_button_color_c6 + ", " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);");
-        ui_->pushButtonDummy1->setStyleSheet( "background-color: rgba(186, 189, 182, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonDummy2->setStyleSheet( "background-color: rgba(186, 189, 182, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonDummy3->setStyleSheet( "background-color: rgba(186, 189, 182, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonDebug->setStyleSheet( "background-color: rgba(85, 87, 83, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
-        ui_->pushButtonMusic->setStyleSheet( "background-color: rgba(78, 154, 6, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);");
-        ui_->pushButtonAndroidAuto->setStyleSheet( "background-color: rgba(48, 140, 198, " + alp + " ); border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255); border-bottom: 0px; border-top: 0px;");
+        ui_->pushButtonExit->setStyleSheet( "QPushButton{background-color: rgba(164, 0, 0, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonShutdown->setStyleSheet( "QPushButton{background-color: rgba(239, 41, 41, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonReboot->setStyleSheet( "QPushButton{background-color: rgba(252, 175, 62, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonCancel->setStyleSheet( "QPushButton{background-color: rgba(32, 74, 135, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonBrightness->setStyleSheet( "QPushButton{background-color: rgba(245, 121, 0, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonVolume->setStyleSheet( "QPushButton{background-color: rgba(64, 191, 191, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonLock->setStyleSheet( "QPushButton{background-color: rgba(15, 54, 5, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonSettings->setStyleSheet( "QPushButton{background-color: rgba(138, 226, 52, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonDay->setStyleSheet( "QPushButton{background: rgba(252, 233, 79, " + alp + " );  outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonNight->setStyleSheet( "QPushButton{background-color: rgba(114, 159, 207, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonCameraShow->setStyleSheet( "QPushButton{background-color: rgba(100, 62, 4, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonWifi->setStyleSheet( "QPushButton{background-color: rgba(252, 175, 62, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonToggleGUI->setStyleSheet( "QPushButton{background-color: rgba(237, 164, 255, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButton_c1->setStyleSheet( "QPushButton{background-color: rgba(" + this->custom_button_color_c1 + ", " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButton_c2->setStyleSheet( "QPushButton{background-color: rgba(" + this->custom_button_color_c2 + ", " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButton_c3->setStyleSheet( "QPushButton{background-color: rgba(" + this->custom_button_color_c3 + ", " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButton_c4->setStyleSheet( "QPushButton{background-color: rgba(" + this->custom_button_color_c4 + ", " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButton_c5->setStyleSheet( "QPushButton{background-color: rgba(" + this->custom_button_color_c5 + ", " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButton_c6->setStyleSheet( "QPushButton{background-color: rgba(" + this->custom_button_color_c6 + ", " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonDummy1->setStyleSheet( "QPushButton{background-color: rgba(186, 189, 182, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonDummy2->setStyleSheet( "QPushButton{background-color: rgba(186, 189, 182, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonDummy3->setStyleSheet( "QPushButton{background-color: rgba(186, 189, 182, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonDebug->setStyleSheet( "QPushButton{background-color: rgba(85, 87, 83, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonMusic->setStyleSheet( "QPushButton{background-color: rgba(78, 154, 6, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
+        ui_->pushButtonAndroidAuto->setStyleSheet( "QPushButton{background-color: rgba(48, 140, 198, " + alp + " ); outline-style: dotted; outline-color: #92a8d1; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255); border-bottom: 0px; border-top: 0px;} QPushButton:focus {border: 2px solid rgba(125,125,125,0.5);}");
         ui_->labelAndroidAutoBottom->setStyleSheet( "background-color: rgba(48, 140, 198, " + alp + " ); border-bottom-left-radius: 4px; border-bottom-right-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255); border-top: 0px;");
         ui_->labelAndroidAutoTop->setStyleSheet( "background-color: rgba(48, 140, 198, " + alp + " ); border-top-left-radius: 4px; border-top-right-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255); border-bottom: 0px;");
         ui_->pushButtonNoDevice->setStyleSheet( "background-color: rgba(48, 140, 198, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);");
@@ -1655,38 +1656,51 @@ bool f1x::openauto::autoapp::ui::MainWindow::check_file_exist(const char *fileNa
     }
 }
 
-void f1x::openauto::autoapp::ui::MainWindow::KeyPress(QString key)
+void f1x::openauto::autoapp::ui::MainWindow::keyPressEvent(QKeyEvent *event)
 {
     if (configuration_->playerButtonControl()) {
-        if (key == "C") {
+        if (event->key() == Qt::Key_C) {
             on_pushButtonPlayerPause_clicked();
         }
-        if (key == "X") {
+        if (event->key() == Qt::Key_X) {
             on_pushButtonPlayerPlayList_clicked();
         }
-        if (key == "V") {
+        if (event->key() == Qt::Key_V) {
             on_pushButtonPlayerPrevBig_clicked();
         }
-        if (key == "N") {
+        if (event->key() == Qt::Key_N) {
             on_pushButtonPlayerNextBig_clicked();
         }
-        if (key == "B") {
+        if (event->key() == Qt::Key_B) {
             on_pushButtonPlayerPause_clicked();
         }
-        if (key == "A") {
-            on_pushButtonPlayerPrevAlbum_clicked();
-        }
-        if (key == "L") {
-            on_pushButtonPlayerNextAlbum_clicked();
-        }
-        if (key == "H") {
+        if (event->key() == Qt::Key_H) {
             if (ui_->mediaWidget->isVisible() == false) {
                 playerShow();
             } else {
                 playerHide();
             }
         }
+        if (event->key() == Qt::Key_A) {
+            on_pushButtonPlayerPrevAlbum_clicked();
+        }
+        if (event->key() == Qt::Key_L) {
+            on_pushButtonPlayerNextAlbum_clicked();
+        }
     }
+    if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Return) {
+        QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyPress, Qt::Key_Space, Qt::NoModifier));
+    }
+    if (event->key() == Qt::Key_1) {
+        QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyPress, Qt::Key_Tab, Qt::ShiftModifier));
+    }
+    if (event->key() == Qt::Key_2) {
+        QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier));
+    }
+    if(event->key() == Qt::Key_Escape)
+    {
+        f1x::openauto::autoapp::ui::MainWindow::toggleExit();
+    }    
 }
 
 void f1x::openauto::autoapp::ui::MainWindow::on_AlbumCoverListView_clicked(const QModelIndex &index)
@@ -2154,4 +2168,3 @@ void f1x::openauto::autoapp::ui::MainWindow::tmpChanged()
     }
     updateNetworkInfo();
 }
-

--- a/src/autoapp/UI/MainWindow.cpp
+++ b/src/autoapp/UI/MainWindow.cpp
@@ -251,8 +251,10 @@ MainWindow::MainWindow(configuration::IConfiguration::Pointer configuration, QWi
 
     if (std::ifstream("/tmp/temp_recent_list") || std::ifstream("/tmp/mobile_hotspot_detected")) {
         ui_->pushButtonWifi->show();
+        ui_->pushButtonWifi->setFocus();
         ui_->pushButtonNoWiFiDevice->hide();
         ui_->pushButtonWifi2->show();
+        ui_->pushButtonWifi2->setFocus();
         ui_->pushButtonNoWiFiDevice2->hide();
     } else {
         ui_->pushButtonWifi->hide();
@@ -809,24 +811,24 @@ void f1x::openauto::autoapp::ui::MainWindow::updateAlpha()
         ui_->pushButtonNoDevice->setStyleSheet( "background-color: rgba(48, 140, 198, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);");
         ui_->pushButtonNoWiFiDevice->setStyleSheet( "background-color: rgba(252, 175, 62, " + alp + " ); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); color: rgb(255,255,255);");
         // old style
-        ui_->pushButtonSettings2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonLock2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonMusic2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonBrightness2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonToggleGUI2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonExit2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonShutdown2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonReboot2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonCancel2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonAndroidAuto2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonNoDevice2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonWifi2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonNoWiFiDevice2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonDay2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonNight2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonCameraShow2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonVolume2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
-        ui_->pushButtonDebug2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5); outline: none;");
+        ui_->pushButtonSettings2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonLock2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonMusic2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonBrightness2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonToggleGUI2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonExit2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonShutdown2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonReboot2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonCancel2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonAndroidAuto2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonNoDevice2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonWifi2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonNoWiFiDevice2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonDay2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonNight2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonCameraShow2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonVolume2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
+        ui_->pushButtonDebug2->setStyleSheet( "background-color: rgba(136, 138, 133, " + alp + " ); color: rgb(255, 255, 255); border-radius: 4px; border: 2px solid rgba(255,255,255,0.5);");
     }
 }
 
@@ -1699,7 +1701,13 @@ void f1x::openauto::autoapp::ui::MainWindow::keyPressEvent(QKeyEvent *event)
     }
     if(event->key() == Qt::Key_Escape)
     {
-        f1x::openauto::autoapp::ui::MainWindow::toggleExit();
+        if (ui_->mediaWidget->isVisible() == true) {
+            playerHide();
+        } else if (this->oldGUIStyle == true) {
+            toggleGUI();            
+        } else {
+            toggleExit();
+        }
     }    
 }
 
@@ -1984,12 +1992,14 @@ void f1x::openauto::autoapp::ui::MainWindow::tmpChanged()
     if (std::ifstream("/tmp/temp_recent_list") || std::ifstream("/tmp/mobile_hotspot_detected")) {
         if (ui_->pushButtonWifi->isVisible() == false) {
             ui_->pushButtonWifi->show();
+            ui_->pushButtonWifi->setFocus();
         }
         if (ui_->pushButtonNoWiFiDevice->isVisible() == true) {
             ui_->pushButtonNoWiFiDevice->hide();
         }
         if (ui_->pushButtonWifi2->isVisible() == false) {
             ui_->pushButtonWifi2->show();
+            ui_->pushButtonWifi2->setFocus();
         }
         if (ui_->pushButtonNoWiFiDevice2->isVisible() == true) {
             ui_->pushButtonNoWiFiDevice2->hide();

--- a/src/autoapp/UI/MainWindow.cpp
+++ b/src/autoapp/UI/MainWindow.cpp
@@ -765,7 +765,6 @@ void f1x::openauto::autoapp::ui::MainWindow::on_horizontalSliderBrightness_value
 
 void f1x::openauto::autoapp::ui::MainWindow::on_horizontalSliderVolume_valueChanged(int value)
 {
-    int n = snprintf(this->volume_str, 5, "%d", value);
     QString vol=QString::number(value);
     ui_->volumeValueLabel->setText(vol+"%");
     system(("/usr/local/bin/autoapp_helper setvolume " + std::to_string(value) + "&").c_str());
@@ -1259,7 +1258,7 @@ void f1x::openauto::autoapp::ui::MainWindow::on_mp3List_itemClicked(QListWidgetI
 
 void f1x::openauto::autoapp::ui::MainWindow::metaDataChanged()
 {
-    QString fullpathplaying = player->currentMedia().canonicalUrl().toString();
+    QString fullpathplaying = player->currentMedia().request().url().toString();
     QString filename = QFileInfo(fullpathplaying).fileName();
 
     QImage img = player->metaData(QMediaMetaData::CoverArtImage).value<QImage>();
@@ -1688,8 +1687,9 @@ void f1x::openauto::autoapp::ui::MainWindow::keyPressEvent(QKeyEvent *event)
             on_pushButtonPlayerNextAlbum_clicked();
         }
     }
-    if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Return) {
+    if (event->key() == Qt::Key_Return) {
         QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyPress, Qt::Key_Space, Qt::NoModifier));
+        QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyRelease, Qt::Key_Space, Qt::NoModifier));
     }
     if (event->key() == Qt::Key_1) {
         QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyPress, Qt::Key_Tab, Qt::ShiftModifier));

--- a/src/autoapp/UI/SettingsWindow.cpp
+++ b/src/autoapp/UI/SettingsWindow.cpp
@@ -1423,13 +1423,14 @@ void f1x::openauto::autoapp::ui::SettingsWindow::keyPressEvent(QKeyEvent *event)
     {
         f1x::openauto::autoapp::ui::SettingsWindow::close();
     }
-    if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Return) {
+    if (event->key() == Qt::Key_Return) {
         QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyPress, Qt::Key_Space, Qt::NoModifier));
+        QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyRelease, Qt::Key_Space, Qt::NoModifier));
     }    
     if (event->key() == Qt::Key_1) {
         QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyPress, Qt::Key_Tab, Qt::ShiftModifier));
     }
     if (event->key() == Qt::Key_2) {
         QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier));
-    }    
+    }
 }

--- a/src/autoapp/UI/SettingsWindow.cpp
+++ b/src/autoapp/UI/SettingsWindow.cpp
@@ -1416,3 +1416,11 @@ void f1x::openauto::autoapp::ui::SettingsWindow::on_pushButtonNetwork1_clicked()
     qApp->processEvents();
     system("/usr/local/bin/crankshaft network 1 >/dev/null 2>&1 &");
 }
+
+void f1x::openauto::autoapp::ui::SettingsWindow::keyPressEvent(QKeyEvent *event)
+{
+    if(event->key() == Qt::Key_Escape)
+    {
+        f1x::openauto::autoapp::ui::SettingsWindow::close();
+    }
+}

--- a/src/autoapp/UI/SettingsWindow.cpp
+++ b/src/autoapp/UI/SettingsWindow.cpp
@@ -1423,4 +1423,13 @@ void f1x::openauto::autoapp::ui::SettingsWindow::keyPressEvent(QKeyEvent *event)
     {
         f1x::openauto::autoapp::ui::SettingsWindow::close();
     }
+    if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Return) {
+        QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyPress, Qt::Key_Space, Qt::NoModifier));
+    }    
+    if (event->key() == Qt::Key_1) {
+        QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyPress, Qt::Key_Tab, Qt::ShiftModifier));
+    }
+    if (event->key() == Qt::Key_2) {
+        QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier));
+    }    
 }

--- a/src/autoapp/UI/UpdateDialog.cpp
+++ b/src/autoapp/UI/UpdateDialog.cpp
@@ -27,7 +27,8 @@ UpdateDialog::UpdateDialog(QWidget *parent)
     connect(ui_->pushButtonUpdateCheck, &QPushButton::clicked, this, &UpdateDialog::on_pushButtonUpdateCheck_clicked);
     connect(ui_->pushButtonUpdateCancel, &QPushButton::clicked, this, &UpdateDialog::on_pushButtonUpdateCancel_clicked);
     connect(ui_->pushButtonClose, &QPushButton::clicked, this, &UpdateDialog::close);
-
+    
+    ui_->pushButtonClose->setFocus();
     ui_->progressBarCsmt->hide();
     ui_->progressBarUdev->hide();
     ui_->progressBarOpenauto->hide();
@@ -208,6 +209,16 @@ void f1x::openauto::autoapp::ui::UpdateDialog::keyPressEvent(QKeyEvent *event)
     {
         UpdateDialog::close();
     }
+    if (event->key() == Qt::Key_Return) {
+        QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyPress, Qt::Key_Space, Qt::NoModifier));
+        QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyRelease, Qt::Key_Space, Qt::NoModifier));
+    }    
+    if (event->key() == Qt::Key_1) {
+        QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyPress, Qt::Key_Tab, Qt::ShiftModifier));
+    }
+    if (event->key() == Qt::Key_2) {
+        QApplication::postEvent (QApplication::focusWidget(), new QKeyEvent ( QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier));
+    }    
 }
 
 }

--- a/src/autoapp/UI/UpdateDialog.cpp
+++ b/src/autoapp/UI/UpdateDialog.cpp
@@ -202,6 +202,14 @@ void f1x::openauto::autoapp::ui::UpdateDialog::updateCheck()
     }
 }
 
+void f1x::openauto::autoapp::ui::UpdateDialog::keyPressEvent(QKeyEvent *event)
+{
+    if(event->key() == Qt::Key_Escape)
+    {
+        UpdateDialog::close();
+    }
+}
+
 }
 }
 }

--- a/src/autoapp/UI/mainwindow.ui
+++ b/src/autoapp/UI/mainwindow.ui
@@ -236,7 +236,6 @@ border-radius: 4px;</string>
            <property name="styleSheet">
             <string notr="true">background-color: rgb(115, 210, 22);
 color: rgb(0, 0, 0);
-outline: none;
 border-radius: 4px;
 </string>
            </property>
@@ -725,7 +724,6 @@ color: rgb(0, 102, 255);</string>
                <property name="styleSheet">
                 <string notr="true">background-color: rgb(164, 0, 0);
 color: rgb(239, 239, 239);
-outline: none;
 border-radius: 4px;
 </string>
                </property>
@@ -817,7 +815,6 @@ border-radius: 4px;
                <property name="styleSheet">
                 <string notr="true">background-color: rgb(32, 74, 135);
 color: rgb(239, 239, 239);
-outline: none;
 border-radius: 4px;
 </string>
                </property>
@@ -1527,7 +1524,6 @@ border-bottom: 0px;</string>
                   <string notr="true">background-color: rgba(48, 140, 198, 0.5);
 color: rgb(255, 255, 255);
 border: 2px solid rgba(255,255,255,0.5);
-outline: none;
 border-top: 0px;
 border-bottom: 0px;
 </string>
@@ -1610,6 +1606,9 @@ outline: none;</string>
                <string>No
 USB Device</string>
               </property>
+              <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
+              </property>
              </widget>
             </item>
            </layout>
@@ -1649,7 +1648,7 @@ USB Device</string>
 border-radius: 4px;
 border: 2px solid rgba(255,255,255,0.5);
 color: rgb(255, 255, 255);
-outline: none;</string>
+               </string>
               </property>
               <property name="text">
                <string/>
@@ -1692,6 +1691,9 @@ outline: none;</string>
                <string>No
 WiFi Clients</string>
               </property>
+              <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
+              </property>              
              </widget>
             </item>
            </layout>
@@ -5519,7 +5521,7 @@ outline: none;</string>
          <property name="styleSheet">
           <string notr="true">color: rgb(255, 255, 255);
 background-color: rgb(164, 0, 0);
-outline: none;</string>
+          </string>
          </property>
          <property name="text">
           <string>Muted</string>
@@ -5548,8 +5550,7 @@ outline: none;</string>
          </property>
          <property name="styleSheet">
           <string notr="true">color: rgb(255, 255, 255);
-background-color: #6d6d6d;
-outline: none;</string>
+background-color: #6d6d6d;</string>
          </property>
          <property name="text">
           <string>Mute</string>

--- a/src/autoapp/UI/mainwindow.ui
+++ b/src/autoapp/UI/mainwindow.ui
@@ -2802,7 +2802,7 @@ outline: none;</string>
                  <string notr="true">background-color: rgba(136, 138, 133, 0.5);
 border-radius: 4px;
 border: 2px solid rgba(255,255,255,0.5);
-outline: none;</string>
+                  </string>
                 </property>
                 <property name="text">
                  <string/>

--- a/src/autoapp/UI/settingswindow.ui
+++ b/src/autoapp/UI/settingswindow.ui
@@ -10718,8 +10718,7 @@ QComboBox::item:selected {
         </font>
        </property>
        <property name="styleSheet">
-        <string notr="true">background-color: rgb(7, 123, 123);
-outline: none;</string>
+        <string notr="true">background-color: rgb(7, 123, 123);</string>
        </property>
        <property name="text">
         <string>Save</string>
@@ -10753,8 +10752,7 @@ outline: none;</string>
         </font>
        </property>
        <property name="styleSheet">
-        <string notr="true">background-color: rgb(206, 92, 0);
-outline: none;</string>
+        <string notr="true">background-color: rgb(7, 123, 123);</string>
        </property>
        <property name="text">
         <string>Reset to default</string>
@@ -10788,8 +10786,7 @@ outline: none;</string>
         </font>
        </property>
        <property name="styleSheet">
-        <string notr="true">background-color: rgb(85, 87, 83);
-outline: none;</string>
+        <string notr="true">background-color: rgb(7, 123, 123);</string>
        </property>
        <property name="text">
         <string>Cancel</string>


### PR DESCRIPTION
Hi, I've added keybord handling in crankshaft UI.
In main menu show focused elements, navigate using TAB, or "1" and "2" keys (rotary keys of android auto).
Esc key handling to go back to main menu from Settings, -Update, Media player, etc.
Set default focus on Wifi button if connection is detected.
Fixes #394.