### PR TITLE
Fix RPI build not working properly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if (WIN32)
     set(WINSOCK2_LIBRARIES "ws2_32")
 endif (WIN32)
 
-if (DEFINED NOPI)
+if (NOPI)
     message(STATUS "Configuring for Non-Raspberry Pi")
 else()
     message(STATUS "Configuring for RaspberryPi")


### PR DESCRIPTION
* NOPI is always set due to line 7, so instead we check if it enabled or not.